### PR TITLE
Attempt into creating an Enumeration type

### DIFF
--- a/widget-src/Enums/Enum.ts
+++ b/widget-src/Enums/Enum.ts
@@ -21,6 +21,7 @@ export const AccessSymbolType = {
 export const TypeType = {
     CLASS: 'class',
     INTERFACE: 'interface',
+    ENUMERATION: 'enumeration',
     ABSTRACT_CLASS: 'abstract class',
 } as const;
 

--- a/widget-src/Parts/ClassNameBlock.tsx
+++ b/widget-src/Parts/ClassNameBlock.tsx
@@ -2,7 +2,7 @@ const { widget } = figma
 const { AutoLayout, Input, Text, SVG } = widget
 
 import { fileIconSvgSrc } from 'classDiagram/Settings/Icon'
-import { isInterface, isAbstractClass } from 'classDiagram/Utils/ClassType'
+import { isInterface, isEnumeration, isAbstractClass } from 'classDiagram/Utils/ClassType'
 
 export const classNameBlock = (
     color: string,
@@ -39,6 +39,24 @@ export const classNameBlock = (
                 </Text>
             </AutoLayout>
             {/** Interface Label End */}
+
+            {/** Enumeration Label */}
+            <AutoLayout
+                verticalAlignItems={'start'}
+                horizontalAlignItems={'start'}
+                width={'fill-parent'}
+                height={34}
+                hidden={! isEnumeration(type)}
+            >
+                <Text
+                    fontSize={20}
+                    fill={'#fff'}
+                    width={'hug-contents'}
+                >
+                    &lt;&lt; enumeration &gt;&gt;
+                </Text>
+            </AutoLayout>
+            {/** Enumeration Label End */}
 
             <AutoLayout
                 verticalAlignItems={'center'}

--- a/widget-src/Utils/ClassType.ts
+++ b/widget-src/Utils/ClassType.ts
@@ -4,6 +4,10 @@ export const isInterface = (type: string) => {
     return type === TypeType.INTERFACE
 }
 
+export const isEnumeration = (type: string) => {
+    return type === TypeType.ENUMERATION
+}
+
 export const isAbstractClass = (type: string) => {
     return type === TypeType.ABSTRACT_CLASS
 }

--- a/widget-src/Utils/Menu.ts
+++ b/widget-src/Utils/Menu.ts
@@ -43,6 +43,7 @@ export const getMenu = (color:string, type: string, size: string): WidgetPropert
             {option: `${TypeType.CLASS}`, label: "Class"},
             {option: `${TypeType.ABSTRACT_CLASS}`, label: "Abstract Class"},
             {option: `${TypeType.INTERFACE}`, label: "Interface"},
+            {option: `${TypeType.ENUMERATION}`, label: "Enumeration"},
             ],
         },
         {


### PR DESCRIPTION
I'd like to propose that we add an `Enumeration` class type the same way the `Interface` class type already exist, as to better showcase the type of classes that we're creating.

I know that traditional enums don't usually have many properties or methods, and instead they're usually just a list of, well, enum types, but I'm happy to accommodate that list in either the properties or the methods bucket for now; I'm mainly interested in the type title being present!

Moreover, I'm not really a Typescript dev, so please let me know if I missed anything!

Happy to revise my PR as long as we can keep this feature request moving forward 🙏 